### PR TITLE
Fix esData issue

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,2 +1,2 @@
-esData
+esData/nodes
 redisData


### PR DESCRIPTION
See #2. The `esData` directory must have user and group ID 1000. When it is not present it gets created with the user and group ID of the user who starts `docker-compose`, which could be root or docker or anyone else on the host system whose ID *is not* 1000. This causes elasticsearch to fail to start.

This pull request adjusts the `docker/.gitignore` to only ignore the contents of the `esData` directory, not the directory itself.

See: [Install Elasticsearch with Docker: Production mode](https://www.elastic.co/guide/en/elasticsearch/reference/6.1/docker.html#docker-cli-run-prod-mode)