### PR TITLE
frontend/package.json: Pin @types/ramda at 0.27.34

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "@types/jasmine": "~3.5.10",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.12.47",
-    "@types/ramda": "^0.27.0",
+    "@types/ramda": "0.27.34",
     "codelyzer": "^5.1.2",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.1",


### PR DESCRIPTION
This fixes a handful of TypeScript errors at runtime.

See: https://github.com/ilri/OpenRXV/issues/81
See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26375