### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,0 +1,22 @@
+# Name that shows up in the badge
+name: Build frontend
+
+# Trigger workflow on pushes and pull requests to all branches
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # Run on current "active" and "maintenance" releases of Node.js
+        # See: https://nodejs.org/en/about/releases/
+        node: [ '10', '12', '14' ]
+    name: Node.js ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: cd frontend; npm install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Repository Explorer and Visualizer
+# Open Repository Explorer and Visualizer ![frontend build status](https://github.com/ilri/OpenRXV/actions/workflows/build-frontend.yml/badge.svg)
 
 The Open Repository Explorer and Visualizer (OpenRXV) is a dashboard-like tool that was created to help people find and understand content in open access repositories like [DSpace](https://duraspace.org/dspace). It began as a proof of concept developed by [CodeObia](http://codeobia.com/) and [the Monitoring, Evaluation and Learning (MEL)](https://mel.cgiar.org) team at the [International Center for Agricultural Research in the Dry Areas (ICARDA)](https://www.icarda.org) to enable exploring and reporting on content in two key institutional repositories. Later, in partnership with the [International Livestock Research Institute (ILRI)](https://www.ilri.org), the scope was expanded with the idea of supporting more repository types and larger amounts of items. In the future we hope to be able to support any repository that uses Dublin Core metadata and has an API for harvesting.
 


### PR DESCRIPTION
Adds a GitHub actions workflow to build the frontend. We use a lot of dependencies in `package.json` and we need to know when the ecosystem has moved enough to break our build.