### PR TITLE
docker/docker-compose.yml: Use docker volumes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       environment:
         - discovery.type=single-node 
       volumes:
-        - ./esData_7:/usr/share/elasticsearch/data:rw            
+        - esData_7:/usr/share/elasticsearch/data:rw
   angular_nginx:
     container_name: angular_nginx 
     image: angular_nginx
@@ -30,7 +30,7 @@ services:
       image: redis
       restart: always
       volumes:
-        - ./redisData:/data
+        - redisData:/data
       ports:
         - 127.0.0.1:6379:6379
   kibana:
@@ -61,3 +61,6 @@ services:
     links:
       - elasticsearch_7   
       - angular_nginx
+volumes:
+  esData_7:
+  redisData:


### PR DESCRIPTION
Use docker volumes instead of bind mounts. This makes the initial experience from a clean install more seamless, as you don't need to mess with sudo, chown, or chmod on the data directories, but is also a more docker-y usage pattern that is more flexible and more performant.

To migrate a bind mount to a docker volume you can create a new volume, attach it to a temporary container, and then copy the data into it:

```console
$ docker-compose -f docker/docker-compose.yml down
$ docker volume create docker_esData_7
$ docker container create --name es_dummy -v docker_esData_7:/usr/share/elasticsearch/data:rw elasticsearch:7.6.2
$ docker cp docker/esData_7/nodes es_dummy:/usr/share/elasticsearch/data
$ docker rm es_dummy
# edit docker/docker-compose.yml to switch from bind mount to volume
$ docker-compose -f docker/docker-compose.yml up -d
```

I did this for both the Redis and Elasticsearch containers on the AReS production environment and it worked.

Note that when you reference a volume called "esData_7" in `docker-compose.yml` Docker will automatically create a volume called "docker_esData_7" so you need to use that name when performing manual Docker operations on the command line. Also, it is not necessary to start the temporary container—you only need to create it with the volume attached in order to copy data into it.