### PR TITLE
docker/docker-compose.yml: Pin Redis to version 5

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
        - elasticsearch_7
   redis:
       container_name: redis
-      image: redis
+      image: redis:5
       restart: always
       volumes:
         - redisData:/data


### PR DESCRIPTION
We are currently using `redis` without a version, which implies the latest version. In effect we deployed this on an image of Redis that is currently twenty-three months (23) old, and is currently [listed on the Redis website as being not only old, but "Older"](https://redis.io/download).

Eventually we should move to Redis 6.x, but for now let's pin the version to 5 so we don't have any surprises.