### PR TITLE
docker/backendBuild/Dockerfile: upgrade npm

### DIFF
--- a/docker/backendBuild/Dockerfile
+++ b/docker/backendBuild/Dockerfile
@@ -2,3 +2,4 @@ FROM node:12-buster
 RUN apt update -y \
     && apt install -y unoconv \
     && rm -rf /var/lib/apt/lists/*
+RUN npm install -g npm


### PR DESCRIPTION
We need to make sure we're using the latest npm so that it can read our package-lock.json which uses lockfile version 2. In testing, my local npm handles the new lockfile format correctly, but when I start the backend container the version of npm there is older and it downgrades the lockfile.