### PR TITLE
Prefix Docker image names with docker.io

### DIFF
--- a/docker/angularBuild/Dockerfile
+++ b/docker/angularBuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM docker.io/ubuntu:20.04
 # Work around tzdata prompting user during apt install (default is UTC anyways)
 # See: https://grigorkh.medium.com/fix-tzdata-hangs-docker-image-build-cdb52cc3360d
 ENV TZ=UTC

--- a/docker/backendBuild/Dockerfile
+++ b/docker/backendBuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-buster
+FROM docker.io/node:12-buster
 RUN apt update -y \
     && apt install -y unoconv \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   elasticsearch_7:
-    image: elasticsearch:7.6.2
+    image: docker.io/elasticsearch:7.6.2
     container_name: elasticsearch_7
     restart: always
     ports:
@@ -30,7 +30,7 @@ services:
       - openrxv
   redis:
     container_name: redis
-    image: redis:5
+    image: docker.io/redis:5
     restart: always
     volumes:
       - redisData:/data
@@ -41,7 +41,7 @@ services:
   kibana:
     container_name: kibana
     restart: always
-    image: kibana:7.6.2
+    image: docker.io/kibana:7.6.2
     depends_on:
       - elasticsearch_7
     ports:


### PR DESCRIPTION
We need to be explicit about which registry we are pulling these images from. Docker itself assumes docker.io, but there are other container registries and other container runtimes don't assume the same, for example podman.