### PR TITLE
frontend: Prefer DOI for Altmetric donut

### DIFF
--- a/frontend/src/app/explorer/dashboard/components/list/paginated-list/paginated-list.component.html
+++ b/frontend/src/app/explorer/dashboard/components/list/paginated-list/paginated-list.component.html
@@ -22,13 +22,23 @@
     *ngIf="content.altmetric"
     class="col-md-1 col-xs-12"
   >
-    <div
+    <div *ngIf="h._source.DOI; else altmetricHandle"
+      data-badge-popover="left"
+      data-badge-type="medium-donut"
+      [attr.data-doi]="h._source.DOI"
+      data-hide-no-mentions="true"
+      class="altmetric-embed sm-text-center"
+    ></div>
+
+    <ng-template #altmetricHandle>
+      <div
       data-badge-popover="left"
       data-badge-type="medium-donut"
       [attr.data-handle]="h._source.handle"
       data-hide-no-mentions="true"
       class="altmetric-embed sm-text-center"
-    ></div>
+      ></div>
+    </ng-template>
   </div>
 </div>
 


### PR DESCRIPTION
Altmetric prefers DOIs so we should use those if the item has one, otherwise try with the handle. If Altmetric's API returns an HTTP 404 we know there is no score and the donut is hidden.