### PR TITLE
.github/workflows: update npm in build

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12'
-      - run: cd backend; npm install
+      - run: npm install -g npm@latest; cd backend; npm install
   format:
     runs-on: ubuntu-20.04
     name: Prettier format check
@@ -24,4 +24,4 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12'
-      - run: cd backend; npm ci; npm run format:check
+      - run: npm install -g npm@latest; cd backend; npm ci; npm run format:check

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12'
-      - run: cd frontend; npm install
+      - run: npm install -g npm@latest; cd frontend; npm install
   lint:
     runs-on: ubuntu-20.04
     name: Prettier format check
@@ -24,4 +24,4 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12'
-      - run: cd frontend; npm ci; npm run format:check
+      - run: npm install -g npm@latest; cd frontend; npm ci; npm run format:check


### PR DESCRIPTION
So we can use v2 lockfiles and avoid this warning during build:

> npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@2. I'll try to do my best with it!

This also more closely follows the behavior we are using in Docker, as all our containers update `npm` before they install packages.