### PR TITLE
docker: Use Debian 11 image for backend

### DIFF
--- a/docker/backendBuild/Dockerfile
+++ b/docker/backendBuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:12-buster
+FROM docker.io/node:12-bullseye
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y \
     && apt install -y --no-install-recommends unoconv libreoffice-writer \


### PR DESCRIPTION
Debian 11 Bullseye replaces Debian 10 Buster as the current stable distribution and has a much newer userland. I tested harvesting, running plugins, committing, and all reports that require unoconv/LibreOffice on the backend (PDF/DOCX).