### PR TITLE
Upgrade Elasticsearch and Kibana to 7.13.2

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "copy:assets": "mkdir -p 'dist/export/services/template-files/' && mkdir -p  data/files/downloads/ &&  cp -r 'src/export/services/template-files/' 'dist/export/services/template-files/'"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^7.7.1",
+    "@elastic/elasticsearch": "^7.8.0",
     "@nestjs/bull": "^0.3.1",
     "@nestjs/common": "^7.6.17",
     "@nestjs/config": "^0.6.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "copy:assets": "mkdir -p 'dist/export/services/template-files/' && mkdir -p  data/files/downloads/ &&  cp -r 'src/export/services/template-files/' 'dist/export/services/template-files/'"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^7.10.0",
+    "@elastic/elasticsearch": "^7.13.0",
     "@nestjs/bull": "^0.3.1",
     "@nestjs/common": "^7.6.17",
     "@nestjs/config": "^0.6.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "copy:assets": "mkdir -p 'dist/export/services/template-files/' && mkdir -p  data/files/downloads/ &&  cp -r 'src/export/services/template-files/' 'dist/export/services/template-files/'"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^7.6.1",
+    "@elastic/elasticsearch": "^7.7.1",
     "@nestjs/bull": "^0.3.1",
     "@nestjs/common": "^7.6.17",
     "@nestjs/config": "^0.6.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "copy:assets": "mkdir -p 'dist/export/services/template-files/' && mkdir -p  data/files/downloads/ &&  cp -r 'src/export/services/template-files/' 'dist/export/services/template-files/'"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^7.9.1",
+    "@elastic/elasticsearch": "^7.10.0",
     "@nestjs/bull": "^0.3.1",
     "@nestjs/common": "^7.6.17",
     "@nestjs/config": "^0.6.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
     "copy:assets": "mkdir -p 'dist/export/services/template-files/' && mkdir -p  data/files/downloads/ &&  cp -r 'src/export/services/template-files/' 'dist/export/services/template-files/'"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^7.8.0",
+    "@elastic/elasticsearch": "^7.9.1",
     "@nestjs/bull": "^0.3.1",
     "@nestjs/common": "^7.6.17",
     "@nestjs/config": "^0.6.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,7 @@
     "@nestjs/common": "^7.6.17",
     "@nestjs/config": "^0.6.3",
     "@nestjs/core": "^7.6.17",
-    "@nestjs/elasticsearch": "^7.1.0",
+    "@nestjs/elasticsearch": "^8.0.0",
     "@nestjs/jwt": "^7.2.0",
     "@nestjs/passport": "^7.1.5",
     "@nestjs/platform-express": "^7.6.17",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   elasticsearch_7:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     container_name: elasticsearch_7
     restart: always
     ports:
@@ -39,7 +39,7 @@ services:
   kibana:
     container_name: kibana
     restart: always
-    image: docker.elastic.co/kibana/kibana:7.9.3
+    image: docker.elastic.co/kibana/kibana:7.10.2
     depends_on:
       - elasticsearch_7
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   elasticsearch_7:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
     container_name: elasticsearch_7
     restart: always
     ports:
@@ -39,7 +39,7 @@ services:
   kibana:
     container_name: kibana
     restart: always
-    image: docker.elastic.co/kibana/kibana:7.8.1
+    image: docker.elastic.co/kibana/kibana:7.9.3
     depends_on:
       - elasticsearch_7
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   elasticsearch_7:
-    image: docker.io/elasticsearch:7.6.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
     container_name: elasticsearch_7
     restart: always
     ports:
@@ -39,7 +39,7 @@ services:
   kibana:
     container_name: kibana
     restart: always
-    image: docker.io/kibana:7.6.2
+    image: docker.elastic.co/kibana/kibana:7.7.1
     depends_on:
       - elasticsearch_7
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   elasticsearch_7:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.2
     container_name: elasticsearch_7
     restart: always
     ports:
@@ -39,7 +39,7 @@ services:
   kibana:
     container_name: kibana
     restart: always
-    image: docker.elastic.co/kibana/kibana:7.10.2
+    image: docker.elastic.co/kibana/kibana:7.13.2
     depends_on:
       - elasticsearch_7
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   elasticsearch_7:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.1
     container_name: elasticsearch_7
     restart: always
     ports:
@@ -39,7 +39,7 @@ services:
   kibana:
     container_name: kibana
     restart: always
-    image: docker.elastic.co/kibana/kibana:7.7.1
+    image: docker.elastic.co/kibana/kibana:7.8.1
     depends_on:
       - elasticsearch_7
     ports:


### PR DESCRIPTION
I tested a few minor versions from 7.7.x to 7.13.x and found that they all worked without issues. Harvesting, plugins, filters, layout, shared links, and reports all work as expected. The limiting factor here _may_ be @nestjs/elasticsearch, which lists explicit support for Elasticsearch version 7.13.0 in their [8.0.0 release](https://github.com/nestjs/elasticsearch/releases/tag/8.0.0).

In addition to increased performance, security and bug fixes, and new features, these upgrades bring some massive infrastructure benefits under the hood:

- Java version 13 → 16 in the Elasticsearch container
- Base image CentOS 7 → 8 in the Elasticsearch container
- Dozens of dependency updates in npm packages

This pays off a few years of technical debt and gets our stack running on modern software. \o/

Note: we need to start looking at deprecation notices in the Elasticsearch logs because there may be some breaking changes coming.